### PR TITLE
[feat] Favorites 저장 기능 구현

### DIFF
--- a/Backend/src/app.module.ts
+++ b/Backend/src/app.module.ts
@@ -7,8 +7,7 @@ import { AppController } from './app.controller';
 import { AuctionModule } from './auctions/auction.module';
 import { MarketModule } from './markets/market.module';
 import { AuthModule } from './auth/auth.module';
-
-import { User } from './auth/entities/user.entity';
+import { FavoritesModule } from './favorites/favorite.module';
 
 @Module({
   imports: [
@@ -28,6 +27,7 @@ import { User } from './auth/entities/user.entity';
     AuctionModule,
     MarketModule,
     AuthModule,
+    FavoritesModule,
   ],
   controllers: [AppController],
 })

--- a/Backend/src/auth/auth.module.ts
+++ b/Backend/src/auth/auth.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
@@ -15,14 +16,18 @@ import { GoogleService } from './google/google.service';
 @Module({
   imports: [
     PassportModule.register({ defaultStrategy: 'jwt' }),
-    JwtModule.register({
-      secret: process.env.JWT_SECRET || 'supersecret',
-      signOptions: { expiresIn: '7d' },
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (cfg: ConfigService) => ({
+        secret: cfg.get<string>('JWT_SECRET') ?? 'supersecret',
+        signOptions: { expiresIn: '7d' },
+      }),
     }),
     TypeOrmModule.forFeature([User]),
   ],
   controllers: [AuthController, GoogleController],
   providers: [AuthService, JwtStrategy, GoogleStrategy, GoogleService],
-  exports: [AuthService],
+  exports: [AuthService, JwtModule],
 })
 export class AuthModule {}

--- a/Backend/src/auth/entities/user.entity.ts
+++ b/Backend/src/auth/entities/user.entity.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Favorite } from 'src/favorites/entities/favorite.entity';
 
 @Entity('users')
 export class User {
@@ -16,4 +17,8 @@ export class User {
 
   @Column({ nullable: true })
   provider: string; // 'google', 'kakao' 등
+
+  // 사용자 기준 즐겨찾기 목록
+  @OneToMany(() => Favorite, (favorite) => favorite.user)
+  favorites: Favorite[];
 }

--- a/Backend/src/auth/jwt.strategy.ts
+++ b/Backend/src/auth/jwt.strategy.ts
@@ -1,17 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(cfg: ConfigService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: process.env.JWT_SECRET || 'supersecret',
+      secretOrKey: cfg.get<string>('JWT_SECRET') ?? 'supersecret',
+      ignoreExpiration: false,
     });
+    // console.log('[JwtStrategy] using secret:', cfg.get('JWT_SECRET'));
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    // console.log('validate() payload:', payload);
+    return { id: payload.sub, email: payload.email };
   }
 }

--- a/Backend/src/favorites/dto/create-favorite.dto.ts
+++ b/Backend/src/favorites/dto/create-favorite.dto.ts
@@ -1,0 +1,27 @@
+// src/favorites/dto/create-favorite.dto.ts
+export class CreateFavoriteDto {
+  source: 'auction' | 'market';
+
+  // 공통
+  name: string;
+  grade: string;
+  icon: string;
+  currentPrice: number;
+  previousPrice?: number;
+  targetPrice?: number;
+
+  // 선택(경매장)
+  tier?: number;
+  quality?: number;
+  auctionInfo?: any;
+  options?: { name: string; value: number; displayValue: number }[];
+
+  // 선택(거래소)
+  itemId?: number;
+  marketInfo?: {
+    currentMinPrice?: number;
+    yDayAvgPrice?: number;
+    recentPrice?: number;
+    tradeRemainCount?: number;
+  };
+}

--- a/Backend/src/favorites/entities/favorite.entity.ts
+++ b/Backend/src/favorites/entities/favorite.entity.ts
@@ -1,0 +1,83 @@
+// src/favorites/entities/favorite.entity.ts
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { User } from 'src/auth/entities/user.entity';
+
+@Entity()
+export class Favorite {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, (user) => user.favorites, { onDelete: 'CASCADE' })
+  user: User;
+
+  @Column()
+  name: string;
+
+  @Column()
+  grade: string;
+
+  // 경매장만 있는 값이므로 nullable 권장
+  @Column({ nullable: true })
+  tier?: number;
+
+  @Column()
+  icon: string;
+
+  @Column({ nullable: true })
+  quality?: number;
+
+  // 공통 스냅샷(표준화한 현재가/이전가)
+  @Column()
+  currentPrice: number; // market이면 recentPrice 또는 currentMinPrice 중 택1
+  @Column({ nullable: true })
+  previousPrice?: number; // market이면 yDayAvgPrice
+
+  @Column({ default: 0 })
+  targetPrice: number;
+
+  @Column()
+  source: 'auction' | 'market';
+
+  // 거래소 식별자(있으면 dedup 등에 유용)
+  @Column({ type: 'bigint', nullable: true })
+  itemId?: number;
+
+  // 경매장 원본 데이터
+  @Column('jsonb', { nullable: true })
+  auctionInfo?: {
+    StartPrice: number;
+    BuyPrice: number;
+    BidPrice: number;
+    EndDate: string;
+    BidCount: number;
+    BidStartPrice: number;
+    IsCompetitive: boolean;
+    TradeAllowCount: number;
+    UpgradeLevel: number | null;
+  };
+
+  // 거래소 원본 데이터
+  @Column('jsonb', { nullable: true })
+  marketInfo?: {
+    currentMinPrice?: number;
+    yDayAvgPrice?: number;
+    recentPrice?: number;
+    tradeRemainCount?: number;
+  };
+
+  @Column('jsonb', { nullable: true })
+  options?: Array<{ name: string; value: number; displayValue: number }>;
+
+  // 폴링/알림 운영용(선택)
+  @Column({ default: false })
+  isAlerted: boolean;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastCheckedAt?: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  lastNotifiedAt?: Date;
+
+  @Column({ default: true })
+  active: boolean;
+}

--- a/Backend/src/favorites/favorite.controller.ts
+++ b/Backend/src/favorites/favorite.controller.ts
@@ -1,0 +1,32 @@
+// src/favorites/favorites.controller.ts
+
+import { Controller, Get, Post, Delete, Patch, Param, Body, Req, UseGuards } from '@nestjs/common';
+import { FavoritesService } from './favorite.service';
+import { JwtAuthGuard } from 'src/auth/jwt.guard';
+import { CreateFavoriteDto } from './dto/create-favorite.dto';
+
+@Controller('favorites')
+@UseGuards(JwtAuthGuard)
+export class FavoritesController {
+  constructor(private readonly favoritesService: FavoritesService) {}
+
+  @Get()
+  findAll(@Req() req) {
+    return this.favoritesService.findAllByUser(req.user.id);
+  }
+
+  @Post()
+  create(@Req() req, @Body() dto: CreateFavoriteDto) {
+    return this.favoritesService.create(req.user.id, dto);
+  }
+
+  @Delete(':id')
+  remove(@Req() req, @Param('id') id: string) {
+    return this.favoritesService.remove(req.user.id, id);
+  }
+
+  @Patch(':id')
+  update(@Req() req, @Param('id') id: string, @Body() body: { targetPrice: number }) {
+    return this.favoritesService.updateTargetPrice(req.user.id, id, body.targetPrice);
+  }
+}

--- a/Backend/src/favorites/favorite.module.ts
+++ b/Backend/src/favorites/favorite.module.ts
@@ -1,0 +1,15 @@
+// src/favorites/favorites.module.ts
+
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Favorite } from './entities/favorite.entity';
+import { FavoritesService } from './favorite.service';
+import { FavoritesController } from './favorite.controller';
+import { User } from 'src/auth/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Favorite, User])],
+  controllers: [FavoritesController],
+  providers: [FavoritesService],
+})
+export class FavoritesModule {}

--- a/Backend/src/favorites/favorite.service.ts
+++ b/Backend/src/favorites/favorite.service.ts
@@ -1,0 +1,154 @@
+// src/favorites/favorites.service.ts
+
+import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, FindOptionsWhere } from 'typeorm';
+import { Favorite } from './entities/favorite.entity';
+import { User } from 'src/auth/entities/user.entity';
+import { CreateFavoriteDto } from './dto/create-favorite.dto';
+
+@Injectable()
+export class FavoritesService {
+  constructor(
+    @InjectRepository(Favorite)
+    private readonly favoriteRepo: Repository<Favorite>,
+
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+  ) {}
+
+  /**
+   * 유저 기준 즐겨찾기 전체 조회 (선택적으로 source 필터링 가능)
+   */
+  async findAllByUser(userId: number, source?: 'auction' | 'market') {
+    const where: FindOptionsWhere<Favorite> = { user: { id: userId } as any };
+    if (source) where.source = source;
+
+    return this.favoriteRepo.find({
+      where,
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * 즐겨찾기 생성
+   * - 공통 스냅샷: currentPrice / previousPrice
+   * - 원본 보존: auctionInfo / marketInfo
+   * - 운영 필드: isAlerted / active / (lastCheckedAt, lastNotifiedAt 초기 null)
+   */
+  async create(userId: number, dto: CreateFavoriteDto) {
+    const user = await this.userRepo.findOneBy({ id: userId });
+    if (!user) throw new NotFoundException('User not found');
+
+    // null → undefined 정리
+    const safeQuality = dto.quality ?? undefined;
+    const safeTier = dto.tier ?? undefined;
+
+    // source별 표준화 스냅샷
+    let normalizedCurrentPrice = dto.currentPrice;
+    let normalizedPreviousPrice = dto.previousPrice; // 그대로 두고 아래에서만 undefined로 조정
+
+    if (dto.source === 'market' && dto.marketInfo) {
+      if (normalizedCurrentPrice == null) {
+        normalizedCurrentPrice = dto.marketInfo.recentPrice ?? dto.marketInfo.currentMinPrice ?? 0;
+      }
+      if (normalizedPreviousPrice == null) {
+        normalizedPreviousPrice = dto.marketInfo.yDayAvgPrice; // number | undefined
+      }
+    }
+
+    if (dto.source === 'auction') {
+      normalizedCurrentPrice = normalizedCurrentPrice ?? 0;
+      // normalizedPreviousPrice는 undefined 그대로 두기
+    }
+
+    const favorite = this.favoriteRepo.create({
+      user, // User는 NotNull 보장
+      source: dto.source,
+
+      name: dto.name,
+      grade: dto.grade,
+      icon: dto.icon,
+
+      currentPrice: normalizedCurrentPrice!,
+      previousPrice: normalizedPreviousPrice ?? undefined, // ✅ 여기! null 금지
+
+      // 선택 필드들
+      tier: safeTier,
+      quality: safeQuality,
+      auctionInfo: dto.auctionInfo ?? undefined,
+      options: dto.options ?? undefined,
+
+      itemId: dto.itemId ?? undefined,
+      marketInfo: dto.marketInfo ?? undefined,
+
+      targetPrice: dto.targetPrice ?? normalizedCurrentPrice ?? 0,
+
+      isAlerted: false,
+      active: true,
+      lastCheckedAt: undefined,
+      lastNotifiedAt: undefined,
+    });
+
+    return this.favoriteRepo.save(favorite);
+  }
+
+  /**
+   * 즐겨찾기 삭제
+   */
+  async remove(userId: number, favoriteId: string) {
+    const favorite = await this.favoriteRepo.findOne({
+      where: { id: favoriteId },
+      relations: ['user'],
+    });
+    if (!favorite) throw new NotFoundException('Favorite not found');
+    if (favorite.user.id !== userId) throw new ForbiddenException();
+
+    await this.favoriteRepo.remove(favorite);
+    return { message: 'Deleted' };
+  }
+
+  /**
+   * 타겟 가격 수정
+   */
+  async updateTargetPrice(userId: number, favoriteId: string, price: number) {
+    const favorite = await this.favoriteRepo.findOne({
+      where: { id: favoriteId },
+      relations: ['user'],
+    });
+    if (!favorite) throw new NotFoundException('Favorite not found');
+    if (favorite.user.id !== userId) throw new ForbiddenException();
+
+    favorite.targetPrice = price;
+    return this.favoriteRepo.save(favorite);
+  }
+
+  /**
+   * (선택) 활성 즐겨찾기 조회 - 스케줄러에서 사용
+   */
+  async findActive() {
+    return this.favoriteRepo.find({ where: { active: true } });
+  }
+
+  /**
+   * (선택) 최신 스냅샷 업데이트 - 스케줄러에서 사용
+   */
+  async updateSnapshot(
+    favoriteId: string,
+    patch: Partial<
+      Pick<
+        Favorite,
+        | 'currentPrice'
+        | 'previousPrice'
+        | 'isAlerted'
+        | 'lastCheckedAt'
+        | 'lastNotifiedAt'
+        | 'auctionInfo'
+        | 'marketInfo'
+      >
+    >,
+  ) {
+    await this.favoriteRepo.update({ id: favoriteId }, patch);
+    return this.favoriteRepo.findOneBy({ id: favoriteId });
+  }
+}

--- a/Backend/src/main.ts
+++ b/Backend/src/main.ts
@@ -5,7 +5,9 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   app.enableCors({
-    origin: process.env.CORS_ORIGIN || 'http://localhost:5173',
+    origin: (process.env.CORS_ORIGIN ?? 'http://localhost:5173').split(','),
+    methods: ['GET', 'POST', 'PATCH', 'DELETE', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization'],
   });
 
   await app.listen(process.env.PORT || 4000);

--- a/Backend/src/markets/market.service.ts
+++ b/Backend/src/markets/market.service.ts
@@ -62,10 +62,13 @@ export class MarketService {
           grade: item.Grade,
           icon: item.Icon,
           bundleCount: item.BundleCount,
-          tradeRemainCount: item.TradeRemainCount,
-          yDayAvgPrice: item.YDayAvgPrice,
-          recentPrice: item.RecentPrice,
-          currentMinPrice: item.CurrentMinPrice,
+          quality: item.Quality,
+          marketInfo: {
+            currentMinPrice: item.CurrentMinPrice,
+            yDayAvgPrice: item.YDayAvgPrice,
+            recentPrice: item.RecentPrice,
+            tradeRemainCount: item.TradeRemainCount,
+          },
         })),
       };
     } catch (err) {

--- a/PwaFrontend/src/App.tsx
+++ b/PwaFrontend/src/App.tsx
@@ -8,6 +8,7 @@ import AppRoutes from './AppRoutes';
 
 const queryClient = new QueryClient();
 
+
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>

--- a/PwaFrontend/src/components/MarketItemCard.tsx
+++ b/PwaFrontend/src/components/MarketItemCard.tsx
@@ -4,17 +4,34 @@ import { Button } from '@/components/ui/button';
 import { Star } from 'lucide-react';
 import { useState } from 'react';
 
+// interface MarketItemCardProps {
+//   item: {
+//     id: number;
+//     name: string;
+//     grade: string;
+//     icon?: string;
+//     currentMinPrice: number;
+//     yDayAvgPrice?: number;
+//     recentPrice?: number;
+//     tradeRemainCount?: number;
+//     quality?: number;
+//   };
+//   onFavorite?: (item: any) => void;
+//   isFavorite?: boolean;
+// }
 interface MarketItemCardProps {
   item: {
-    id: number;
+    id: string;
     name: string;
     grade: string;
     icon?: string;
-    currentMinPrice: number;
-    yDayAvgPrice?: number;
-    recentPrice?: number;
-    tradeRemainCount?: number;
     quality?: number;
+    marketInfo?: {
+      currentMinPrice: number;
+      yDayAvgPrice?: number;
+      recentPrice?: number;
+      tradeRemainCount?: number;
+    };
   };
   onFavorite?: (item: any) => void;
   isFavorite?: boolean;
@@ -86,27 +103,34 @@ const MarketItemCard = ({ item, onFavorite, isFavorite = false }: MarketItemCard
       <CardContent className="p-3 sm:p-4 pt-0">
         <div className="space-y-2 sm:space-y-3">
           {/* ✅ 최소가 */}
+          {/* {(item.currentMinPrice ?? item.recentPrice ?? 0).toLocaleString()}G */}
           <div className="flex items-center justify-between">
             <span className="text-xs sm:text-sm text-muted-foreground">최소가</span>
             <span className="text-sm sm:text-lg font-bold text-primary">
-              {item.currentMinPrice.toLocaleString()}G
+              {item.marketInfo?.currentMinPrice?.toLocaleString() ?? 0}G
             </span>
           </div>
 
           {/* ✅ 전일 평균 */}
-          {item.yDayAvgPrice !== undefined && (
+          {/* {item.yDayAvgPrice !== undefined && ( */}
+          {/* {item.yDayAvgPrice.toLocaleString()}G */}
+          {item.marketInfo?.yDayAvgPrice !== undefined && (
             <div className="flex items-center justify-between">
               <span className="text-xs text-muted-foreground">전일 평균</span>
-              <span className="text-sm font-bold">{item.yDayAvgPrice.toLocaleString()}G</span>
+              <span className="text-sm font-bold">
+                {item.marketInfo?.yDayAvgPrice?.toLocaleString() ?? 0}G
+              </span>
             </div>
           )}
 
           {/* ✅ 잔여 거래 */}
-          {item.tradeRemainCount !== undefined && (
+          {/* {item.tradeRemainCount} */}
+          {/* {item.tradeRemainCount !== undefined && ( */}
+          {item.marketInfo?.tradeRemainCount !== undefined && (
             <div className="flex items-center justify-between">
               <span className="text-xs text-muted-foreground">잔여 거래</span>
               <Badge variant="secondary" className="text-xs">
-                {item.tradeRemainCount}
+                {item.marketInfo?.tradeRemainCount ?? 0}
               </Badge>
             </div>
           )}

--- a/PwaFrontend/src/pages/AuctionHouse.tsx
+++ b/PwaFrontend/src/pages/AuctionHouse.tsx
@@ -9,6 +9,7 @@ import CategoryFilter from '@/components/pages/CategoryFilter';
 import { CategoryEtcOptions } from '@/constants/etcOptions';
 import EtcOptionsFilter from '@/components/pages/EtcOptionsFilter';
 import { searchAuctions } from '@/services/auction.dto';
+import { addFavorite } from '@/services/favorites.service';
 
 const AuctionHouse = () => {
   const [filters, setFilters] = useState({
@@ -97,6 +98,29 @@ const AuctionHouse = () => {
     });
   }, [results, filters]);
 
+  const handleAddFavorite = async (item: any) => {
+    try {
+      const saved = await addFavorite({
+        source: 'auction', // ✅ Auction 전용
+        name: item.name,
+        grade: item.grade,
+        tier: item.tier,
+        icon: item.icon,
+        quality: item.quality,
+        currentPrice: item.currentPrice,
+        previousPrice: item.previousPrice,
+        auctionInfo: item.auctionInfo,
+        options: item.options,
+        itemId: item.itemId,
+      });
+      console.log('즐겨찾기 저장 성공:', saved);
+      alert('즐겨찾기에 추가되었습니다!');
+    } catch (err) {
+      console.error('즐겨찾기 저장 실패:', err);
+      alert('로그인이 필요합니다.');
+    }
+  };
+
   return (
     <div className="min-h-screen p-4 bg-background">
       <div className="max-w-6xl mx-auto">
@@ -146,7 +170,7 @@ const AuctionHouse = () => {
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {filteredItems.map((item, idx) => (
-            <ItemCard key={item.id ?? idx} item={item} onFavorite={(i) => console.log('Fav:', i)} />
+            <ItemCard key={item.id ?? idx} item={item} onFavorite={() => handleAddFavorite(item)} />
           ))}
         </div>
 

--- a/PwaFrontend/src/pages/Market.tsx
+++ b/PwaFrontend/src/pages/Market.tsx
@@ -8,6 +8,7 @@ import { Filter, Search } from 'lucide-react';
 import { marketCategories } from '@/constants/marketCategories';
 import SearchBar from '@/components/pages/SearchBar';
 import { searchMarket } from '@/services/market.dto';
+import { addFavorite } from '@/services/favorites.service';
 
 const Market = () => {
   const [selectedCategory, setSelectedCategory] = useState<number | 'All'>('All');
@@ -37,6 +38,28 @@ const Market = () => {
 
   const handleChange = (key: string, value: any) => {
     setFilters((prev) => ({ ...prev, [key]: value, pageNo: 1 }));
+  };
+
+  const handleFavorite = async (item: any) => {
+    try {
+      await addFavorite({
+        source: 'market',
+        name: item.name,
+        grade: item.grade,
+        icon: item.icon,
+        currentPrice: item.recentPrice ?? item.currentMinPrice ?? 0,
+        previousPrice: item.yDayAvgPrice,
+        marketInfo: {
+          currentMinPrice: item.currentMinPrice,
+          yDayAvgPrice: item.yDayAvgPrice,
+          recentPrice: item.recentPrice,
+          tradeRemainCount: item.tradeRemainCount,
+        },
+      });
+      console.log('✅ 즐겨찾기 추가 성공:', item.name);
+    } catch (err) {
+      console.error('❌ 즐겨찾기 추가 실패:', err);
+    }
   };
 
   const filteredItems = items.filter((item) => {
@@ -127,19 +150,23 @@ const Market = () => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {items.map((item) => (
+          {items.map((item, index) => (
             <MarketItemCard
-              key={item.id}
+              key={`${item.id}-${index}`}
               item={{
                 id: item.id,
                 name: item.name,
                 grade: item.grade,
                 icon: item.icon,
-                currentMinPrice: item.currentMinPrice,
-                yDayAvgPrice: item.yDayAvgPrice,
-                recentPrice: item.recentPrice,
-                tradeRemainCount: item.tradeRemainCount,
+                quality: item.quality,
+                marketInfo: {
+                  currentMinPrice: item.marketInfo?.currentMinPrice ?? 0,
+                  yDayAvgPrice: item.marketInfo?.yDayAvgPrice ?? 0,
+                  recentPrice: item.marketInfo?.recentPrice ?? 0,
+                  tradeRemainCount: item.marketInfo?.tradeRemainCount ?? 0,
+                },
               }}
+              onFavorite={handleFavorite}
             />
           ))}
         </div>

--- a/PwaFrontend/src/services/favorites.dto.ts
+++ b/PwaFrontend/src/services/favorites.dto.ts
@@ -1,0 +1,24 @@
+export type FavoriteSource = 'auction' | 'market';
+
+export interface FavoritePayload {
+  source: FavoriteSource;
+  name: string;
+  grade: string;
+  icon: string;
+  tier?: number;
+  quality?: number;
+  currentPrice: number;
+  previousPrice?: number;
+  auctionInfo?: Record<string, any>;
+  marketInfo?: Record<string, any>;
+  options?: Array<{ name: string; value: number; displayValue: number }>;
+  itemId?: number;
+  targetPrice?: number;
+}
+
+export interface FavoriteResponse extends FavoritePayload {
+  id: string;
+  targetPrice: number;
+  isAlerted: boolean;
+  active: boolean;
+}

--- a/PwaFrontend/src/services/favorites.service.ts
+++ b/PwaFrontend/src/services/favorites.service.ts
@@ -1,0 +1,64 @@
+import type { FavoritePayload, FavoriteResponse } from './favorites.dto';
+
+const API = import.meta.env.VITE_API_URL ?? 'http://localhost:4000';
+
+function getToken() {
+  const token = localStorage.getItem('access_token');
+  if (!token) throw new Error('로그인이 필요합니다.');
+  return token;
+}
+
+// ✅ 즐겨찾기 전체 조회
+export async function fetchFavorites(): Promise<FavoriteResponse[]> {
+  const token = getToken();
+  const res = await fetch(`${API}/favorites`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) throw new Error(`즐겨찾기 조회 실패: ${res.status}`);
+  return res.json();
+}
+
+// ✅ 즐겨찾기 추가
+export async function addFavorite(payload: FavoritePayload): Promise<FavoriteResponse> {
+  const token = getToken();
+  const res = await fetch(`${API}/favorites`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) throw new Error(`즐겨찾기 추가 실패: ${res.status}`);
+  return res.json();
+}
+
+// ✅ 즐겨찾기 삭제
+export async function removeFavorite(id: string): Promise<{ message: string }> {
+  const token = getToken();
+  const res = await fetch(`${API}/favorites/${id}`, {
+    method: 'DELETE',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) throw new Error(`즐겨찾기 삭제 실패: ${res.status}`);
+  return res.json();
+}
+
+// ✅ 타겟 가격 수정
+export async function updateTargetPrice(id: string, price: number): Promise<FavoriteResponse> {
+  const token = getToken();
+  const res = await fetch(`${API}/favorites/${id}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ targetPrice: price }),
+  });
+
+  if (!res.ok) throw new Error(`타겟 가격 수정 실패: ${res.status}`);
+  return res.json();
+}


### PR DESCRIPTION
## 📌 작업 내용

- 즐겨찾기(Favorites) 저장 기능 구현
- 경매장(Auction)과 거래소(Market) 아이템 모두 즐겨찾기로 등록할 수 있도록 통합

## 🔍 변경 사항

- favorites.service.ts 추가: 즐겨찾기 조회/저장/삭제/타겟가격 수정 API 유틸 함수 구현
- onFavorite 이벤트에서 favorites.service 호출하고 API 연동을 통해 아이템을 즐겨찾기에 등록 가능
- 공통 구조 통일: marketInfo, auctionInfo 구조로 매핑하여 프론트에서 item={item} 전달만으로 처리 가능하게 개선

## 🔗 관련 이슈

- Close #이슈번호

## ✅ 체크리스트

- [x] 코드가 정상 동작하는지 확인
- [x] 스타일 가이드에 맞게 작성했는지 확인
- [ ] 불필요한 주석/코드 제거
- [ ] 관련 문서/테스트 업데이트
